### PR TITLE
Integrate QtKeychain with quarks-specific changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ kwallet_interface.moc
 moc_keychain.*
 moc_keychain_p.*
 moc_gnomekeyring_p.*
-qkeychain_export.h
 qt_Qt5Keychain.pri
 
 #Qt files

--- a/ReadMe.markdown
+++ b/ReadMe.markdown
@@ -1,1 +1,0 @@
-ReadMe.txt

--- a/gnomekeyring_p.h
+++ b/gnomekeyring_p.h
@@ -45,7 +45,7 @@ public:
         } attributes[32];
     } PasswordSchema;
 
-    typedef void ( *OperationGetStringCallback )( Result result, bool binary,
+    typedef void ( *OperationGetStringCallback )( Result result,
                                                   const char* string, gpointer data );
     typedef void ( *OperationDoneCallback )( Result result, gpointer data );
     typedef void ( *GDestroyNotify )( gpointer data );

--- a/keychain.cpp
+++ b/keychain.cpp
@@ -57,7 +57,7 @@ void Job::doStart() {
 }
 
 void Job::emitFinished() {
-    emit finished( this );
+    Q_EMIT finished( this );
     if ( d->autoDelete )
         deleteLater();
 }

--- a/libsecret.cpp
+++ b/libsecret.cpp
@@ -244,6 +244,9 @@ bool LibSecretKeyring::findPassword(const QString &user, const QString &server,
                                NULL);
     return true;
 #else
+    Q_UNUSED(user)
+    Q_UNUSED(server)
+    Q_UNUSED(self)
     return false;
 #endif
 }
@@ -281,6 +284,12 @@ bool LibSecretKeyring::writePassword(const QString &display_name,
                               NULL);
     return true;
 #else
+    Q_UNUSED(display_name)
+    Q_UNUSED(user)
+    Q_UNUSED(server)
+    Q_UNUSED(mode)
+    Q_UNUSED(password)
+    Q_UNUSED(self)
     return false;
 #endif
 }
@@ -300,6 +309,9 @@ bool LibSecretKeyring::deletePassword(const QString &key, const QString &service
                               NULL);
     return true;
 #else
+    Q_UNUSED(key)
+    Q_UNUSED(service)
+    Q_UNUSED(self)
     return false;
 #endif
 }

--- a/qkeychain_export.h
+++ b/qkeychain_export.h
@@ -1,0 +1,16 @@
+#ifndef QKEYCHAIN_EXPORT_H
+#define QKEYCHAIN_EXPORT_H
+
+#include <QtCore/qglobal.h>
+# ifdef QKEYCHAIN_STATICLIB
+    #undef QKEYCHAIN_SHAREDLIB
+    #define QKEYCHAIN_EXPORT
+# else
+    #if defined(QKEYCHAIN_SHAREDLIB)
+        #define QKEYCHAIN_EXPORT Q_DECL_EXPORT
+    #else
+        #define QKEYCHAIN_EXPORT Q_DECL_IMPORT
+    #endif
+# endif
+
+#endif //QKEYCHAIN_EXPORT_H

--- a/qtkeychain.qbs
+++ b/qtkeychain.qbs
@@ -1,0 +1,139 @@
+import qbs
+
+Product
+{
+    name: "qtkeychain"
+    type: buildStatic ? "staticlibrary" : "dynamiclibrary"
+    targetName: "qtkeychain"
+
+    property bool buildTranslations: false
+    property bool buildStatic: false
+    property bool libsecretSupport: false
+
+    Depends { name: "Quarks" }
+    Depends { name: "cpp" }
+    Depends { name: "Qt.core" }
+    Depends { name: "Qt.dbus"; condition: qbs.targetOS.contains("linux") }
+
+    condition: Quarks.enabledQuarks.contains("qtkeychain")
+
+    cpp.defines: [ buildStatic ? "QKEYCHAIN_STATICLIB" : "QKEYCHAIN_SHAREDLIB" ]
+
+    cpp.includePaths:
+    [
+        "."
+    ]
+
+    Group
+    {
+        name: "Source"
+        files:
+        [
+            "keychain.cpp",
+            "keychain.h",
+            "keychain_p.h",
+            "qkeychain_export.h"
+        ]
+    }
+
+    Group
+    {
+        condition: buildTranslations
+        name: "Translations"
+        files: [ "translations/*.ts" ]
+    }
+
+    Export
+    {
+        Depends { name: "cpp" }
+        Depends { name: "Qt.core" }
+        Depends { name: "Qt.dbus"; condition: qbs.targetOS.contains("linux") }
+
+        cpp.includePaths:
+        [
+            "."
+        ]
+    }
+
+    // linux support
+    Group
+    {
+        condition: qbs.targetOS.contains("linux")
+        name: "Linux Support"
+        files:
+        [
+            "keychain_unix.cpp",
+            "gnomekeyring.cpp",
+            "gnomekeyring_p.h",
+            "plaintextstore.cpp",
+            "plaintextstore_p.h",
+            "libsecret.cpp",
+            "libsecret_p.h"
+        ]
+    }
+
+    Group
+    {
+        condition: qbs.targetOS.contains("linux")
+        name: "DBus interface generation"
+        files: "org.kde.KWallet.xml"
+        fileTags: ["qt.dbus.interface"]
+    }
+
+    // Libsecret support
+    Properties
+    {
+        condition: qbs.targetOS.contains("linux") && libsecretSupport
+        cpp.defines: outer.concat(["HAVE_LIBSECRET=1"])
+    }
+
+    // Windows configuration (defaults to use Windows Credential Store for Win7+)
+    Properties
+    {
+        condition: qbs.targetOS.contains("windows")
+        cpp.defines: outer.concat(["USE_CREDENTIAL_STORE=1"])
+    }
+
+    Group
+    {
+        condition: qbs.targetOS.contains("windows")
+        name: "Windows Support"
+        files:
+        [
+            "keychain_win.cpp",
+            "plaintextstore.cpp",
+            "plaintextstore_p.h"
+        ]
+    }
+
+    // macOS / iOS configuration
+    Properties
+    {
+        condition: qbs.targetOS.contains("macos") || qbs.targetOS.contains("ios")
+        cpp.frameworks:
+        [
+            "Security",
+            "Foundation"
+        ]
+    }
+
+    Group
+    {
+        condition: qbs.targetOS.contains("macos")
+        name: "macOS"
+        files: ["keychain_mac.cpp"]
+    }
+
+    Group
+    {
+        condition: qbs.targetOS.contains("ios")
+        name: "iOS"
+        files: ["keychain_ios.mm"]
+    }
+
+    Group
+    {
+        fileTagsFilter: "dynamiclibrary"
+        qbs.install: true
+    }
+}

--- a/qtkeychain.qbs
+++ b/qtkeychain.qbs
@@ -10,12 +10,9 @@ Product
     property bool buildStatic: false
     property bool libsecretSupport: false
 
-    Depends { name: "Quarks" }
     Depends { name: "cpp" }
     Depends { name: "Qt.core" }
     Depends { name: "Qt.dbus"; condition: qbs.targetOS.contains("linux") }
-
-    condition: Quarks.enabledQuarks.contains("qtkeychain")
 
     cpp.defines: [ buildStatic ? "QKEYCHAIN_STATICLIB" : "QKEYCHAIN_SHAREDLIB" ]
 


### PR DESCRIPTION
References proemion/hyperion/issues/247

QtKeychain provides a way to store credentials in a cross-platform fashion. The library relies on cmake as a build system. This PR integrates a qbs receipt and also provides fixes for warnings/issues which would result in compilation failures for our setup.

The code has been tested on Windows 10/7 and gnome (F29). I had no way to test it on KDE. It should be noted that we should support Win primarily. Hence we can disable the library on Linux if it turns out we have blockers on KDE. :man_shrugging: 

Testing tool available for download [here](https://github.com/frankosterfeld/qtkeychain/files/2993970/TestingQtKeychain.zip).